### PR TITLE
Call setTabPath when creating item group

### DIFF
--- a/src/main/java/com/allkillernofiller/obsidianexpansion/ObsidianExpansion.java
+++ b/src/main/java/com/allkillernofiller/obsidianexpansion/ObsidianExpansion.java
@@ -34,10 +34,10 @@ public class ObsidianExpansion {
         RenderTypeLookup.setRenderLayer(BlockInit.CRYING_OBSIDIAN_GLASS.get(), RenderType.getCutout());
     }
 
-    public static final ItemGroup TAB = new ItemGroup("expansionTab") {
+    public static final ItemGroup TAB = (new ItemGroup("expansionTab") {
         @Override
         public ItemStack createIcon() {
             return new ItemStack(BlockInit.WEAK_OBSIDIAN.get());
         }
-    };
+    }).setTabPath("expansion_tab");
 }


### PR DESCRIPTION
When trying to use datagen to generate recipes for items that are in the obsidian expansion tab, there is an exception because the tab has a capital letter in the label and does not set its tab path to a string using only lowercase characters (see `ItemGroup#BUILDING_BLOCKS` for an example). This PR fixes the issue by simply calling `setTabPath` and passing a lowercase version of the tab label.